### PR TITLE
Covid cases by country including population

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Generated data
 data/
 
+# Jupyter notebooks
+*.ipynb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/data.py
+++ b/data.py
@@ -55,12 +55,15 @@ def covid():
     return df
 
 
-def population():
-    subprocess.call(["rm", "-rf", POP_DIR])
-    os.makedirs(POP_DIR, exist_ok=True)
-    subprocess.call(["curl", POP_URL, "-o", POP_ZIP], cwd=POP_DIR)
-    subprocess.call(["unzip", "-u", POP_ZIP], cwd=POP_DIR)
+def population_csv_files():
+    return glob.glob(os.path.join(POP_DIR, "API_SP.POP.TOTL*.csv"))
 
-    csv_file = glob.glob(os.path.join(POP_DIR, "API_SP.POP.TOTL*.csv"))[0]
-    df = pd.read_csv(csv_file, skiprows=2, header=1)
+
+def population():
+    if len(population_csv_files()) == 0:
+        os.makedirs(POP_DIR, exist_ok=True)
+        subprocess.call(["curl", POP_URL, "-o", POP_ZIP], cwd=POP_DIR)
+        subprocess.call(["unzip", "-u", POP_ZIP], cwd=POP_DIR)
+
+    df = pd.read_csv(population_csv_files()[0], skiprows=2, header=1)
     return df[df.columns[:-1]]


### PR DESCRIPTION
Before of joining the covid data frame with the population data frame, first we group by country and sum up the numeric columns. This is available in wdf. We also still have cdf, which is the original covid data frame without joining with population data.

A few additional changes here:

1. Ignore Jupyter notebooks from now on.
1. Population data will no longer update on every run. In order to get fresh population data, you have to delete the population directory. This should be fine since population doesn't change sufficiently frequently for it to matter.
1. Made all fields snake_case.